### PR TITLE
Add onLinkResult postmessage handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ The `EbtBalanceListenerDelegate` is responsible for communicating to your iOS ap
 ```swift
 public protocol EbtBalanceListenerDelegate {
     func onExit()
+    // onLinkSuccess is deprecated. Use onLinkResult
     func onLinkSuccess(linkToken: String)
+    func onLinkResult(result: LinkResult)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ The `EbtBalanceListenerDelegate` is responsible for communicating to your iOS ap
 ```swift
 public protocol EbtBalanceListenerDelegate {
     func onExit()
-    // onLinkSuccess is deprecated. Use onLinkResult
-    func onLinkSuccess(linkToken: String)
     func onLinkResult(result: LinkResult)
 }
 ```

--- a/Sources/BennySDK/EbtBalance/EbtBalanceViewController.swift
+++ b/Sources/BennySDK/EbtBalance/EbtBalanceViewController.swift
@@ -17,7 +17,7 @@ public class EbtBalanceViewController: UIViewController, WKNavigationDelegate {
     var webViewVM: BaseWebViewVM
     var bennyView: WKWebView
     var delegate: EbtBalanceListenerDelegate?
-    
+
     public init(parameters: EbtBalanceParameters, delegate: EbtBalanceListenerDelegate?) {
         var webResource: String
         var baseUrl: String
@@ -37,19 +37,19 @@ public class EbtBalanceViewController: UIViewController, WKNavigationDelegate {
         self.delegate = delegate
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     // Required initializer when subclassing UIViewController
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override public func loadView() {
         webViewVM.loadWebPage()
         view = bennyView
         bennyView.navigationDelegate = self
     }
-    
+
     public func webView(_: WKWebView, didFinish _: WKNavigation!) {
         _ = EbtBalanceListener(webView: bennyView, delegate: delegate)
     }
@@ -60,13 +60,13 @@ public struct EbtBalanceViewControllerRepresentable: UIViewControllerRepresentab
     var orgId: String
     var temporaryLink: String
     var viewController: EbtBalanceViewController
-    
+
     public init(parameters: EbtBalanceParameters, delegate: EbtBalanceListenerDelegate?) {
         self.orgId = parameters.organizationId
         self.temporaryLink = parameters.temporaryLink
         self.viewController = EbtBalanceViewController(parameters: parameters, delegate: delegate)
     }
-    
+
     public func makeUIViewController(context _: Context) -> UIViewController {
         return viewController
     }

--- a/Sources/BennySDK/EbtBalance/Types.swift
+++ b/Sources/BennySDK/EbtBalance/Types.swift
@@ -26,17 +26,47 @@ public enum Environment: Codable {
 }
 
 public struct CopyToClipboardMessage: Codable {
-    var type = "CopyToClipboard"
-    var label: String
-    var text: String
+    public var type = "CopyToClipboard"
+    public var label: String
+    public var text: String
 }
 
+/*
+ * Deprecated and replaced by LinkResultMessage.
+ */
+
 public struct LinkSuccessMessage: Codable {
-    var type: String
-    var linkToken: String
+    public var type: String
+    public var linkToken: String
+}
+
+public struct LinkResultMessage: Codable {
+    public var type = "LinkResult"
+    public var result: LinkResult
+}
+
+public typealias LinkResult = LinkResultSuccess
+
+public struct LinkResultSuccess: Codable {
+    public var type = "LinkResultSuccess"
+    public var linkToken: String
+    public var accountId: String
+    public var accountHolder: AccountHolder
+}
+
+public struct AccountHolder: Codable {
+    public var name: String?
+    public var address: String?
+    public var balances: Balances
+    public var lastTransactionDate: String?
+}
+
+public struct Balances: Codable {
+    public var snap: Double?
+    public var cash: Double?
 }
 
 public struct OpenUrlMessage: Codable {
-    var type = "OpenUrlExternally"
-    var url: String
+    public var type = "OpenUrlExternally"
+    public var url: String
 }

--- a/Sources/BennySDK/Internals/BaseView.swift
+++ b/Sources/BennySDK/Internals/BaseView.swift
@@ -10,13 +10,13 @@ class BaseWebViewVM: ObservableObject {
     init(webResource: String? = nil) {
         self.webResource = webResource
         webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
-        
+
         #if DEBUG
         if #available(iOS 16.4, *) {
             webView.isInspectable = true
         }
         #endif
-    
+
     }
 
     func loadWebPage() {

--- a/benny-sample-app/bennysampleapp.xcodeproj/project.pbxproj
+++ b/benny-sample-app/bennysampleapp.xcodeproj/project.pbxproj
@@ -380,7 +380,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Benny-API/benny-ios-sdk.git";
 			requirement = {
-				branch = "ab-ebt-balance";
+				branch = "ab-on-link-result";
 				kind = branch;
 			};
 		};

--- a/benny-sample-app/bennysampleapp/ContentView.swift
+++ b/benny-sample-app/bennysampleapp/ContentView.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
             }
         }
     }
-    
+
     var controller: EbtBalanceViewControllerRepresentable {
         let ebtBalanceParams = EbtBalanceParameters(organizationId: "org_wup29bz683g8habsxvazvyz1", environment: Environment.SANDBOX, temporaryLink: "temp_clr0vujq9000108l66odc7fxv")
         let listener = ExampleEbtBalanceListener(isPresentingView: $isPresentingViewController)

--- a/benny-sample-app/bennysampleapp/ExampleListener.swift
+++ b/benny-sample-app/bennysampleapp/ExampleListener.swift
@@ -11,18 +11,28 @@ import BennySDK
 
 class ExampleEbtBalanceListener: EbtBalanceListenerDelegate {
     var isPresentingView: Binding<Bool>
-    
+
     init(isPresentingView: Binding<Bool>) {
         self.isPresentingView = isPresentingView
     }
-    
+
     func onExit() {
         print("exiting flow")
         isPresentingView.wrappedValue.toggle()
     }
-    
+
+    /**
+     *   Deprecated in favor of onLinkResult
+     */
+
     func onLinkSuccess(linkToken: String) {
         print("link success")
         print(linkToken)
     }
+
+    func onLinkResult(result: LinkResultMessage) {
+        print("link result")
+        print((result.result as LinkResultSuccess).linkToken)
+    }
+
 }

--- a/benny-sample-app/bennysampleapp/ExampleListener.swift
+++ b/benny-sample-app/bennysampleapp/ExampleListener.swift
@@ -34,5 +34,4 @@ class ExampleEbtBalanceListener: EbtBalanceListenerDelegate {
         print("link result")
         print((result.result as LinkResultSuccess).linkToken)
     }
-
 }


### PR DESCRIPTION
The onLinkResult postmessage handler will be used in favor of the now deprecated onLinkSuccess 